### PR TITLE
add custom task file to install cmem-plugin-base from working code

### DIFF
--- a/TaskfileCustom.yaml
+++ b/TaskfileCustom.yaml
@@ -1,0 +1,36 @@
+version: '3'
+
+tasks:
+  container:install:
+    desc: "Install plugin package into container (copied to /tmp)"
+    cmds:
+      - |
+        echo "Checking if container is running..."
+        docker inspect -f '{{.State.Running}}' dockerlocalhost-dataintegration-1 || (echo "Container not running!" && exit 1)
+
+      - |
+        echo "Locating plugin package in dist/..."
+        PACKAGE=$(ls dist/cmem_plugin_base-*.tar.gz | head -n 1)
+        echo "Found package: $PACKAGE"
+
+        echo "Copying package to /tmp in container..."
+        docker cp "$PACKAGE" dockerlocalhost-dataintegration-1:/tmp/
+
+        echo "Installing package in container from /tmp..."
+        docker exec dockerlocalhost-dataintegration-1 bash -c "pip install /tmp/$(basename $PACKAGE) --target /data/python-packages/ --upgrade && rm /tmp/$(basename $PACKAGE)"
+
+  container:restart:
+    desc: "Restart the dockerlocalhost-dataintegration-1 container"
+    cmds:
+      - echo "Restarting container dockerlocalhost-dataintegration-1..."
+      - docker restart dockerlocalhost-dataintegration-1
+
+  container:reload:
+    desc: "Build, install, and restart container to reload the plugin"
+    cmds:
+      - echo "Building plugin package..."
+      - task build
+      - echo "Installing package into container..."
+      - task custom:container:install
+      - echo "Restarting container to apply changes..."
+      - task custom:container:restart

--- a/TaskfileCustom.yaml
+++ b/TaskfileCustom.yaml
@@ -1,36 +1,29 @@
+---
 version: '3'
 
 tasks:
+
   container:install:
-    desc: "Install plugin package into container (copied to /tmp)"
+    desc: "Install package in container (then restart)"
+    summary: >
+      Note that `cmemc admin workspace python uninstall cmem-plugin-base` will
+      uninstall the dev-version and reveal the shipped package version again.
     cmds:
-      - |
-        echo "Checking if container is running..."
-        docker inspect -f '{{.State.Running}}' dockerlocalhost-dataintegration-1 || (echo "Container not running!" && exit 1)
+      - task clean build
+      - docker cp dist/{{.PACKAGE_FILE}} {{.DI_CONTAINER}}:/tmp/
+      - docker exec -t {{.DI_CONTAINER}} bash -c "{{.PIP_COMMAND}} /tmp/{{.PACKAGE_FILE}}"
+      - docker exec -t {{.DI_CONTAINER}} bash -c "rm -f /tmp/{{.PACKAGE_FILE}}"
+      - docker restart {{.DI_CONTAINER}}
+    preconditions:
+      - sh: '[ "{{.DI_RUNNING}}" == "true" ]'
+        msg: "Container {{.DI_CONTAINER}} not running ({{.DI_RUNNING}})"
+    vars:
+      DI_CONTAINER: dockerlocalhost-dataintegration-1
+      DI_RUNNING:
+        sh: docker inspect -f '{{ "{{" }}.State.Running{{ "}}" }}' {{.DI_CONTAINER}}
+      PACKAGE: cmem_plugin_base
+      PACKAGE_VERSION:
+        sh: poetry version -s
+      PACKAGE_FILE: "{{.PACKAGE}}-{{.PACKAGE_VERSION}}.tar.gz"
+      PIP_COMMAND: pip install --target /data/python-packages -q --upgrade
 
-      - |
-        echo "Locating plugin package in dist/..."
-        PACKAGE=$(ls dist/cmem_plugin_base-*.tar.gz | head -n 1)
-        echo "Found package: $PACKAGE"
-
-        echo "Copying package to /tmp in container..."
-        docker cp "$PACKAGE" dockerlocalhost-dataintegration-1:/tmp/
-
-        echo "Installing package in container from /tmp..."
-        docker exec dockerlocalhost-dataintegration-1 bash -c "pip install /tmp/$(basename $PACKAGE) --target /data/python-packages/ --upgrade && rm /tmp/$(basename $PACKAGE)"
-
-  container:restart:
-    desc: "Restart the dockerlocalhost-dataintegration-1 container"
-    cmds:
-      - echo "Restarting container dockerlocalhost-dataintegration-1..."
-      - docker restart dockerlocalhost-dataintegration-1
-
-  container:reload:
-    desc: "Build, install, and restart container to reload the plugin"
-    cmds:
-      - echo "Building plugin package..."
-      - task build
-      - echo "Installing package into container..."
-      - task custom:container:install
-      - echo "Restarting container to apply changes..."
-      - task custom:container:restart


### PR DESCRIPTION
This PR adds a TaskfileCustom.yaml to streamline local development and deployment of plugin packages into the dockerlocalhost-dataintegration-1 container.