### PR TITLE
Add related plugins support to PluginDescription and Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 
 - Plugins can be deprecated now (CMEM-6706)
+- Plugins can now reference related plugins via `related_plugins` (CMEM-7549)
 
 ## [4.16.1] 2026-02-20
 

--- a/cmem_plugin_base/dataintegration/description.py
+++ b/cmem_plugin_base/dataintegration/description.py
@@ -62,6 +62,18 @@ class Icon:
         return f"""data:{self.mime_type};base64,{data_base64}"""
 
 
+class PluginReference:
+    """A reference to a related plugin.
+
+    :param plugin_id: The identifier of the related plugin.
+    :param description: An optional description of the relationship.
+    """
+
+    def __init__(self, plugin_id: str, description: str = "") -> None:
+        self.plugin_id = plugin_id
+        self.description = description
+
+
 class PluginParameter:
     """A plugin parameter.
 
@@ -188,6 +200,7 @@ class PluginDescription:
     :param actions: Custom plugin actions.
     :param deprecation: Optional deprecation message.
         If set, the plugin will be marked as deprecated in the UI.
+    :param related_plugins: Optional list of references to related plugins.
     """
 
     def __init__(  # noqa: PLR0913
@@ -202,6 +215,7 @@ class PluginDescription:
         icon: Icon | None = None,
         actions: list[PluginAction] | None = None,
         deprecation: str | None = None,
+        related_plugins: list[PluginReference] | None = None,
     ) -> None:
         #  Set the type of the plugin. Same as the class name of the plugin
         #  base class, e.g., 'WorkflowPlugin'.
@@ -242,6 +256,10 @@ class PluginDescription:
         else:
             self.actions = actions
         self.deprecation = deprecation
+        if related_plugins is None:
+            self.related_plugins = []
+        else:
+            self.related_plugins = related_plugins
         for action in self.actions:
             action.validate(plugin_class)
 
@@ -327,6 +345,7 @@ class Plugin:
     :param actions: Custom plugin actions
     :param deprecation: Optional deprecation message.
         If set, the plugin will be marked as deprecated in the UI.
+    :param related_plugins: Optional list of references to related plugins.
     """
 
     plugins: ClassVar[list[PluginDescription]] = []
@@ -342,6 +361,7 @@ class Plugin:
         icon: Icon | None = None,
         actions: list[PluginAction] | None = None,
         deprecation: str | None = None,
+        related_plugins: list[PluginReference] | None = None,
     ):
         self.label = label
         self.description = description
@@ -350,6 +370,7 @@ class Plugin:
         self.icon = icon
         self.actions = actions
         self.deprecation = deprecation
+        self.related_plugins = related_plugins
         if categories is None:
             self.categories = []
         else:
@@ -372,6 +393,7 @@ class Plugin:
             icon=self.icon,
             actions=self.actions,
             deprecation=self.deprecation,
+            related_plugins=self.related_plugins,
         )
         Plugin.plugins.append(plugin_desc)
         return func

--- a/cmem_plugin_base/dataintegration/description.py
+++ b/cmem_plugin_base/dataintegration/description.py
@@ -203,7 +203,7 @@ class PluginDescription:
     :param related_plugins: Optional list of references to related plugins.
     """
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: PLR0912, PLR0913
         self,
         plugin_class: type,
         label: str,

--- a/cmem_plugin_base/dataintegration/description.py
+++ b/cmem_plugin_base/dataintegration/description.py
@@ -203,7 +203,7 @@ class PluginDescription:
     :param related_plugins: Optional list of references to related plugins.
     """
 
-    def __init__(  # noqa: PLR0912, PLR0913
+    def __init__(  # noqa: PLR0913
         self,
         plugin_class: type,
         label: str,
@@ -239,27 +239,15 @@ class PluginDescription:
             )
         else:
             self.plugin_id = plugin_id
-        if categories is None:
-            self.categories = []
-        else:
-            self.categories = categories
+        self.categories = categories if categories is not None else []
         self.label = label
         self.description = description
         self.documentation = documentation
-        if parameters is None:
-            self.parameters = []
-        else:
-            self.parameters = parameters
+        self.parameters = parameters if parameters is not None else []
         self.icon = icon
-        if actions is None:
-            self.actions = []
-        else:
-            self.actions = actions
+        self.actions = actions if actions is not None else []
         self.deprecation = deprecation
-        if related_plugins is None:
-            self.related_plugins = []
-        else:
-            self.related_plugins = related_plugins
+        self.related_plugins = related_plugins if related_plugins is not None else []
         for action in self.actions:
             action.validate(plugin_class)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1563,14 +1563,14 @@ syntax = ["tree-sitter (>=0.25.0) ; python_version >= \"3.10\"", "tree-sitter-ba
 
 [[package]]
 name = "trivy-py-ecc"
-version = "0.68.2.1"
+version = "0.69.3.1"
 description = "Python wrapper around invoking trivy (https://trivy.dev/)"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "trivy_py_ecc-0.68.2.1-py2.py3-none-manylinux2014_x86_64.whl", hash = "sha256:568a84931302cc26a117da9b5616fa51c873f46bcfc0dc8b87a4c53c1a5674b4"},
-    {file = "trivy_py_ecc-0.68.2.1.tar.gz", hash = "sha256:4d8e66bbf99ac2a59ec705421bace102cc85fb7528bef72e132b50fbbc83e681"},
+    {file = "trivy_py_ecc-0.69.3.1-py2.py3-none-manylinux2014_x86_64.whl", hash = "sha256:4f629e5a750dba12377c5b0b71c9fb1bd7a18523da85f6f889af4b2ab5b6cb73"},
+    {file = "trivy_py_ecc-0.69.3.1.tar.gz", hash = "sha256:ac02db504cc92f5824b4327fa00261f9168709114a0bdd70c99b482348be32c2"},
 ]
 
 [[package]]
@@ -1652,4 +1652,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13, ^3"
-content-hash = "6d03f2e04417f3632167c17d1c930d62d1ee61b1512d80e79dc9cff291757777"
+content-hash = "455acbc0b6ea9f27b46181d8b7228f709f929e20c987659cf8bc819607de4f47"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ pytest-dotenv = "^0.5.2"
 pytest-html = "^4.2.0"
 pytest-memray = { version = "^1.8.0",  markers = "platform_system != 'Windows'" }
 ruff = "^0.15.0"
-trivy-py-ecc = "^0.68.2.1"
+trivy-py-ecc = "^0.69.3.1"
 types-requests = "^2.32.0.20240907"
 
 [build-system]


### PR DESCRIPTION
# Related plugins support

Introduces `PluginReference` — a small class carrying a `plugin_id` and an optional `description` of the relationship — and wires it into both `PluginDescription` and the `@Plugin` decorator via a new `related_plugins` parameter.

Plugin authors can now declare related plugins directly in the annotation:

```python
@Plugin(
    label="My Plugin",
    related_plugins=[
        PluginReference(plugin_id="some-other-plugin", description="Recommended replacement"),
        PluginReference(plugin_id="another-plugin")
    ]
)
```

The field defaults to an empty list and is purely additive — no existing plugins are affected. DataIntegration reads it via jep and exposes it in the plugin list API as part of CMEM-7549.

Also bumps `trivy-py-ecc` to `0.69.3.1`, which was required to build on Python 3.13 — the previous version failed with a PEP 517 wheel build error.