### PR TITLE
fix GraphParameterType.autocomplete (sorting and matching)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/)
 
+## [Unreleased]
+
+### Fixed
+
+- GraphParameterType.autocomplete: results are now sorted by label and only include graphs matching all given query terms, instead of an unsorted, non-deterministic order matching any single term
+
+
 ## [4.20.0] 2026-08-14 - shipped with DI v26.2.0
 
 ### Added

--- a/cmem_plugin_base/dataintegration/parameter/graph.py
+++ b/cmem_plugin_base/dataintegration/parameter/graph.py
@@ -89,13 +89,12 @@ class GraphParameterType(StringParameterType):
             if len(query_terms) == 0:
                 result.append(Autocompletion(value=iri, label=label))
                 continue
-            # show only graphs which match the given terms
-            for term in query_terms:
-                if term.lower() in label.lower():
-                    result.append(Autocompletion(value=iri, label=label))
-                    continue
+            # show only graphs which match all given terms
+            if all(term.lower() in label.lower() for term in query_terms):
+                result.append(Autocompletion(value=iri, label=label))
+        result = list(dict.fromkeys(result))
         result.sort(key=lambda x: x.label)  # type: ignore[return-value, arg-type]
-        return list(set(result))
+        return result
 
     def _validate_graph(self) -> None:
         """Verify that graph name is valid aka it has at least a scheme and something after it"""

--- a/tests/parameter_types/fixture/alpha_sort_test_graph.ttl
+++ b/tests/parameter_types/fixture/alpha_sort_test_graph.ttl
@@ -1,0 +1,6 @@
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix void: <http://rdfs.org/ns/void#> .
+
+<https://ns.eccenca.com/cmem-plugin-base/tests/graph-parameter-type/alpha-sort-test-graph>
+    a void:Dataset ;
+    rdfs:label "Alpha CmemPluginBase SortRegressionTest Graph" .

--- a/tests/parameter_types/fixture/zulu_sort_test_graph.ttl
+++ b/tests/parameter_types/fixture/zulu_sort_test_graph.ttl
@@ -1,0 +1,6 @@
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix void: <http://rdfs.org/ns/void#> .
+
+<https://ns.eccenca.com/cmem-plugin-base/tests/graph-parameter-type/zulu-sort-test-graph>
+    a void:Dataset ;
+    rdfs:label "Zulu CmemPluginBase SortRegressionTest Graph" .

--- a/tests/parameter_types/test_graph.py
+++ b/tests/parameter_types/test_graph.py
@@ -1,35 +1,78 @@
 """graph parameter type tests"""
 
-import pytest
+from collections.abc import Generator
+from dataclasses import dataclass
+from pathlib import Path
 
+import pytest
+from cmem_client.repositories.protocols.import_item import ImportConflictPolicy
+
+from cmem_plugin_base.dataintegration.client import get_client
 from cmem_plugin_base.dataintegration.parameter.graph import GraphParameterType
 from cmem_plugin_base.testing import TestPluginContext
-from tests.utils import needs_cmem
+from tests.utils import get_autocomplete_values, needs_cmem
+
+FIXTURE_DIR = Path(__file__).parent / "fixture"
+
+ALPHA_GRAPH_IRI = (
+    "https://ns.eccenca.com/cmem-plugin-base/tests/graph-parameter-type/alpha-sort-test-graph"
+)
+ZULU_GRAPH_IRI = (
+    "https://ns.eccenca.com/cmem-plugin-base/tests/graph-parameter-type/zulu-sort-test-graph"
+)
+
+
+@dataclass
+class SortTestGraphs:
+    """Two known test graphs used to verify result sorting and ALL-terms matching."""
+
+    alpha_iri: str
+    zulu_iri: str
+
+
+@pytest.fixture(name="sort_test_graphs", scope="module")
+def _sort_test_graphs() -> Generator[SortTestGraphs]:
+    """Provide two known graphs for sort/match assertions, cleaned up afterwards"""
+    client = get_client(TestPluginContext())
+    client.graphs.import_item(
+        path=FIXTURE_DIR / "alpha_sort_test_graph.ttl",
+        key=ALPHA_GRAPH_IRI,
+        on_conflict=ImportConflictPolicy.REPLACE,
+    )
+    client.graphs.import_item(
+        path=FIXTURE_DIR / "zulu_sort_test_graph.ttl",
+        key=ZULU_GRAPH_IRI,
+        on_conflict=ImportConflictPolicy.REPLACE,
+    )
+    try:
+        yield SortTestGraphs(alpha_iri=ALPHA_GRAPH_IRI, zulu_iri=ZULU_GRAPH_IRI)
+    finally:
+        client.graphs.delete_item(ALPHA_GRAPH_IRI, skip_if_missing=True)
+        client.graphs.delete_item(ZULU_GRAPH_IRI, skip_if_missing=True)
 
 
 @needs_cmem
-def test_graph_parameter_type_completion() -> None:
-    """Test graph parameter type completion"""
-    parameter = GraphParameterType(show_system_graphs=True)
+def test_graph_parameter_type_completion(sort_test_graphs: SortTestGraphs) -> None:
+    """Test graph parameter type completion: sorting and ALL-terms matching"""
+    parameter = GraphParameterType()
     context = TestPluginContext()
-    assert "https://ns.eccenca.com/data/queries/" in [
-        x.value
-        for x in parameter.autocomplete(
-            query_terms=["Query", "Catalog"],
-            depend_on_parameter_values=[],
-            context=context,
-        )
-    ]
-    assert (
-        len(
-            parameter.autocomplete(
-                query_terms=["not there asödlkasöld"],
-                depend_on_parameter_values=[],
-                context=context,
-            )
-        )
-        == 0
+
+    # both fixture graphs match all three terms, and must come back sorted by label
+    values = get_autocomplete_values(
+        parameter, ["CmemPluginBase", "SortRegressionTest", "Graph"], context
     )
+    assert sort_test_graphs.alpha_iri in values
+    assert sort_test_graphs.zulu_iri in values
+    assert values.index(sort_test_graphs.alpha_iri) < values.index(sort_test_graphs.zulu_iri)
+
+    # an additional term only present in the "Alpha" label must narrow results to just that graph
+    narrowed_values = get_autocomplete_values(
+        parameter, ["CmemPluginBase", "SortRegressionTest", "Alpha"], context
+    )
+    assert sort_test_graphs.alpha_iri in narrowed_values
+    assert sort_test_graphs.zulu_iri not in narrowed_values
+
+    assert len(get_autocomplete_values(parameter, ["not there asödlkasöld"], context)) == 0
 
 
 def test_graph_validation() -> None:


### PR DESCRIPTION
GraphParameterType.autocomplete: results are now sorted by label and only include graphs matching all given query terms, instead of an unsorted, non-deterministic order matching any single term